### PR TITLE
returning function for inserts

### DIFF
--- a/src/jetquery.zig
+++ b/src/jetquery.zig
@@ -531,7 +531,6 @@ test "combined" {
         .where(.{ .name = "Hercules" })
         .limit(10)
         .orderBy(.{ .name = .ascending });
-    std.debug.print("\n\n\n\n\n", .{});
     try std.testing.expectEqualStrings(
         \\SELECT "cats"."name", "cats"."paws" FROM "cats" WHERE "cats"."name" = $1 ORDER BY "cats"."name" ASC LIMIT $2
     , query.sql);

--- a/src/jetquery.zig
+++ b/src/jetquery.zig
@@ -333,6 +333,19 @@ test "insert" {
     try std.testing.expect(query.isValid());
 }
 
+test "insert with returning" {
+    const Schema = struct {
+        pub const Cat = Model(@This(), "cats", struct { name: []const u8, paws: i32 }, .{});
+    };
+    const query = Query(TestAdapter, Schema, .Cat)
+        .insert(.{ .name = "Hercules", .paws = 4 })
+        .returning(.{.name});
+    try std.testing.expectEqualStrings(
+        \\INSERT INTO "cats" ("name", "paws") VALUES ($1, $2) RETURNING "cats"."name"
+    , query.sql);
+    try std.testing.expect(query.isValid());
+}
+
 test "update" {
     const Schema = struct {
         pub const Cat = Model(@This(), "cats", struct { name: []const u8, paws: i32 }, .{});
@@ -518,7 +531,7 @@ test "combined" {
         .where(.{ .name = "Hercules" })
         .limit(10)
         .orderBy(.{ .name = .ascending });
-
+    std.debug.print("\n\n\n\n\n", .{});
     try std.testing.expectEqualStrings(
         \\SELECT "cats"."name", "cats"."paws" FROM "cats" WHERE "cats"."name" = $1 ORDER BY "cats"."name" ASC LIMIT $2
     , query.sql);

--- a/src/jetquery/Query.zig
+++ b/src/jetquery/Query.zig
@@ -655,6 +655,7 @@ fn Statement(
             return self.extend(S, args, .insert);
         }
 
+        /// Return a subset of columns from the inserted record. An empty array will return all columns.
         pub fn returning(
             self: Self,
             comptime return_columns: anytype,

--- a/src/jetquery/Query.zig
+++ b/src/jetquery/Query.zig
@@ -95,6 +95,10 @@ pub fn Query(adapter: jetquery.adapters.Name, Schema: type, comptime model: anyt
             return InitialStatement(Adapter, Schema, Model).insert(args);
         }
 
+        pub fn returning(comptime columns: anytype) @TypeOf(InitialStatement(Adapter, Schema, Model).returning(columns)) {
+            return InitialStatement(Adapter, Schema, Model).returning(columns);
+        }
+
         /// Create a `DELETE` query. As a safety measure, a `delete()` query **must** have a
         /// `.where()` clause attached or it will not be executed. Use `deleteAll()` if you wish
         /// to delete all records.
@@ -297,7 +301,7 @@ fn defaultResultContext(query_context: sql.QueryContext) ResultContext {
     return switch (query_context) {
         .select => .many,
         .update, .update_all, .insert, .delete, .delete_all, .none => .none,
-        .count => .one,
+        .count, .returning => .one,
     };
 }
 
@@ -649,6 +653,30 @@ fn Statement(
                     timestampsFields(Adapter, Model, .insert)),
             });
             return self.extend(S, args, .insert);
+        }
+
+        pub fn returning(
+            self: Self,
+            comptime return_columns: anytype,
+        ) Statement(Adapter, .returning, Schema, Model, .{
+            .relations = options.relations,
+            .field_infos = options.field_infos,
+            .columns = &jetquery.columns.translate(Model, options.relations, return_columns),
+            .order_clauses = options.order_clauses,
+            .group_by = options.group_by,
+            .distinct = options.distinct,
+            .result_context = .one,
+        }) {
+            const S = Statement(Adapter, .returning, Schema, Model, .{
+                .relations = options.relations,
+                .field_infos = options.field_infos,
+                .columns = &jetquery.columns.translate(Model, options.relations, return_columns),
+                .order_clauses = options.order_clauses,
+                .group_by = options.group_by,
+                .distinct = options.distinct,
+                .result_context = .one,
+            });
+            return self.extend(S, .{}, .returning);
         }
 
         pub fn delete(self: Self) Statement(Adapter, .delete, Schema, Model, .{

--- a/src/jetquery/Repo.zig
+++ b/src/jetquery/Repo.zig
@@ -1144,7 +1144,7 @@ test "relations" {
     try std.testing.expectEqual(20, lila.id);
     const fluffy = try repo.Query(.Cat)
         .insert(.{ .id = lila.id, .name = "Fluffy", .paws = 4, .human_id = 1 })
-        .returning(.{.id, .paws})
+        .returning(.{})
         .execute(&repo) orelse return try std.testing.expect(false);
     defer repo.free(fluffy);
     try std.testing.expectEqual(20, fluffy.id);

--- a/src/jetquery/Repo.zig
+++ b/src/jetquery/Repo.zig
@@ -1135,6 +1135,20 @@ test "relations" {
             else => try std.testing.expect(false),
         }
     }
+
+    const lila = try repo.Query(.Human)
+        .insert(.{ .id = 20, .name = "Lila"})
+        .returning(.{.id})
+        .execute(&repo) orelse return try std.testing.expect(false);
+    defer repo.free(lila);
+    try std.testing.expectEqual(20, lila.id);
+    const fluffy = try repo.Query(.Cat)
+        .insert(.{ .id = lila.id, .name = "Fluffy", .paws = 4, .human_id = 1 })
+        .returning(.{.id, .paws})
+        .execute(&repo) orelse return try std.testing.expect(false);
+    defer repo.free(fluffy);
+    try std.testing.expectEqual(20, fluffy.id);
+    try std.testing.expectEqual(4, fluffy.paws);
 }
 
 test "timestamps" {

--- a/src/jetquery/fields.zig
+++ b/src/jetquery/fields.zig
@@ -4,7 +4,7 @@ const jetcommon = @import("jetcommon");
 
 const Where = @import("sql/Where.zig");
 
-pub const FieldContext = enum { where, update, insert, limit, offset, order, none };
+pub const FieldContext = enum { where, update, insert, limit, offset, order, none, returning };
 
 pub const FieldInfo = struct {
     info: std.builtin.Type.StructField,
@@ -65,7 +65,7 @@ pub fn FieldValues(Table: type, relations: []const type, comptime fields: []cons
 pub fn ColumnType(Adapter: type, Table: type, comptime field_info: FieldInfo) type {
     switch (field_info.context) {
         .limit, .offset => return usize,
-        .where, .update, .insert, .order, .none => {},
+        .where, .update, .insert, .order, .none, .returning => {},
     }
 
     if (comptime @hasField(Table.Definition, field_info.name)) {

--- a/src/jetquery/sql.zig
+++ b/src/jetquery/sql.zig
@@ -19,6 +19,7 @@ pub const QueryContext = enum {
     delete,
     delete_all,
     count,
+    returning,
     none,
 };
 

--- a/src/jetquery/sql/render.zig
+++ b/src/jetquery/sql/render.zig
@@ -178,13 +178,10 @@ fn renderReturning(
     comptime columns: []const jetquery.columns.Column,
 ) []const u8 {
     comptime {
-        var params_buf: [paramsBufSize(Adapter, field_infos, .insert, .column)]u8 = undefined;
-        var values_buf: [paramsBufSize(Adapter, field_infos, .insert, .value)]u8 = undefined;
+        const insert_slice = renderInsert(Adapter, Table, field_infos);
         const select_columns = renderSelectColumns(Adapter, relations, columns);
-        return std.fmt.comptimePrint("INSERT INTO {s} ({s}) VALUES ({s}) RETURNING{s}", .{
-            Adapter.identifier(Table.name),
-            renderParams(&params_buf, Adapter, field_infos, .insert, .column),
-            renderParams(&values_buf, Adapter, field_infos, .insert, .value),
+        return std.fmt.comptimePrint("{s} RETURNING{s}", .{
+            insert_slice,
             select_columns,
         });
     }


### PR DESCRIPTION
`.returning(.{.id, .name})` returns only selected columns, `.returning(.{})` returns all columns.

I popped one of the functional tests into the bottom of an existing one in Repo.zig, wasn't sure where the best place to stick it would be.