### PR TITLE
Remove drain in `all`

### DIFF
--- a/src/jetquery/Repo.zig
+++ b/src/jetquery/Repo.zig
@@ -1137,7 +1137,7 @@ test "relations" {
     }
 
     const lila = try repo.Query(.Human)
-        .insert(.{ .id = 20, .name = "Lila"})
+        .insert(.{ .id = 20, .name = "Lila" })
         .returning(.{.id})
         .execute(&repo) orelse return try std.testing.expect(false);
     defer repo.free(lila);
@@ -1417,6 +1417,15 @@ test "transactions" {
         .execute(&repo);
     defer repo.free(no_cat);
     try std.testing.expect(no_cat == null);
+
+    const query = jetquery.Query(.postgresql, Schema, .Cat).insert(.{
+        .name = "Waiting",
+        .paws = 3,
+    }).returning(.{.name});
+    try repo.begin();
+    const waited = try repo.execute(query) orelse return std.testing.expect(false);
+    try repo.rollback();
+    try std.testing.expect(std.mem.eql(u8, waited.name, "Waiting"));
 
     try repo.begin();
     try repo.insert(.Cat, .{ .name = "Hercules", .paws = 4 });

--- a/src/jetquery/adapters/PostgresqlAdapter.zig
+++ b/src/jetquery/adapters/PostgresqlAdapter.zig
@@ -91,7 +91,6 @@ pub fn Result(AdaptedRepo: type) type {
 
             var array = std.ArrayList(@TypeOf(query).ResultType).init(self.allocator);
             while (try self.next(query)) |row| try array.append(row);
-            try self.drain();
             return try array.toOwnedSlice();
         }
 


### PR DESCRIPTION
Hi!

When a transaction is running, calling drain hangs the application.
Usually the connection is idle and it just returns, maybe this also should be fixed in pg.zig i don't think this is expected behavior.
https://github.com/karlseguin/pg.zig/blob/master/src/result.zig#L63

I removed the drain, since we already iterate until `next` is null, so based on the [documentation](https://github.com/karlseguin/pg.zig?tab=readme-ov-file#drainresult-result-void), that drain is redundant.

Closes #7 