### PR TITLE
[Migration] Set default col type to integer when it's a reference column.

### DIFF
--- a/src/jetquery/Migration.zig
+++ b/src/jetquery/Migration.zig
@@ -191,11 +191,13 @@ const Command = struct {
             }
 
             fn writeColumn(column: Column, writer: anytype) !void {
+                const column_type = column.type orelse if (column.reference_column != null) .integer else .string;
+
                 try writer.print(
                     \\t.column("{s}", .{s}, .{{
                 , .{
                     column.name orelse return error.MissingColumnName,
-                    @tagName(column.type orelse .string),
+                    @tagName(column_type),
                 });
                 var options_count: usize = 0;
                 inline for (comptime std.enums.values(Column.options)) |tag| {
@@ -570,7 +572,7 @@ test "migration from command line: create table" {
         \\            t.primaryKey("id", .{}),
         \\            t.column("name", .string, .{ .unique = true, .index = true }),
         \\            t.column("paws", .integer, .{}),
-        \\            t.column("human_id", .string, .{ .optional = true, .index = true, .reference = .{ "humans", "id" } }),
+        \\            t.column("human_id", .integer, .{ .optional = true, .index = true, .reference = .{ "humans", "id" } }),
         \\            t.timestamps(.{}),
         \\        },
         \\        .{},

--- a/src/jetquery/Migration.zig
+++ b/src/jetquery/Migration.zig
@@ -191,7 +191,14 @@ const Command = struct {
             }
 
             fn writeColumn(column: Column, writer: anytype) !void {
-                const column_type = column.type orelse if (column.reference_column != null) .integer else .string;
+                var column_type: DataType = undefined;
+                if (column.type) |t| {
+                    column_type = t;
+                } else if (column.reference_column != null) {
+                    column_type = .integer;
+                } else {
+                    column_type = .string;
+                }
 
                 try writer.print(
                     \\t.column("{s}", .{s}, .{{


### PR DESCRIPTION
As above, setting it as integer if it's a foreign key, otherwise it would be string, retaining existing behavior.