### PR TITLE
Ignore hidden files that start with .

### DIFF
--- a/src/generate_migrations.zig
+++ b/src/generate_migrations.zig
@@ -28,6 +28,7 @@ pub fn main() !void {
     );
     for (migrations) |migration| {
         const basename = std.fs.path.basename(migration);
+        if (basename[0] == '.') continue;
         const version = basename[0.."2000-01-01_12-00-00".len];
         try std.fs.copyFileAbsolute(
             migration,


### PR DESCRIPTION
Particularly `.DS_Store` on Mac. Migration would fail if the hidden file is present on migrations directory.

Users usually are not aware of the file creation on a Mac as it's not only automatically created by Finder, it's also hidden — therefore very hard to debug.

Error when `.DS_Store` is present.

```
$ jetzig database rollback
[exec] zig build -Denvironment=development jetzig:database:rollback
warning: [zmpl] Templates path not found: `src/app/mailers` - skipping.
jetzig:database:rollback
└─ run database
   └─ zig build-exe database Debug native
      └─ run migrations (migrations.zig) failure
thread 42356 panic: index out of bounds: index 19, len 9
/path/to/.cache/zig/p/jetquery-0.0.0-TNf3zjZWBgCLlUMITutBU9dP72AfSVYobcdYJ4AmJT2H/src/generate_migrations.zig:31:33: 0x1009a281f in main (migrations)
        const version = basename[0.."2000-01-01_12-00-00".len];
                                ^
/path/to/zig/lib/std/start.zig:656:37: 0x1009a32e7 in main (migrations)
            const result = root.main() catch |err| {
                                    ^
???:?:?: 0x18a866b4b in ??? (???)
???:?:?: 0x0 in ??? (???)
error: the following command terminated unexpectedly:
/path/to/Project/.zig-cache/o/898b22b3a29409675a63345c17e4fc1e/migrations /path/to/Project/.zig-cache/o/2f126d2b6eeac10de1582e0a47af2ad2/migrations.zig /path/to/Project/src/app/database/migrations/.DS_Store /path/to/Project/src/app/database/migrations/_______________
```